### PR TITLE
fig関数の持つバグの修正

### DIFF
--- a/style/abst_bachelor_style.typ
+++ b/style/abst_bachelor_style.typ
@@ -63,30 +63,38 @@
     set par(leading: 4.5pt, justify: true)
     set text(size: 11.4pt)
     set align(top)
-    grid(
-      columns: 2,
-      {
-        if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
-          counter(figure.where(kind: "sub-figure")).update(0)
-        }
 
-        if it.kind == table{
-          [Table ] + context counter(figure.where(kind: table)).display() + [　]
-        }
-        else if it.kind == raw{
-          [Code ] + context counter(figure.where(kind: raw)).display() + [　]
-        }
-        else if it.kind == "sub-figure"{
-          it.supplement
-          context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0))
-          [　]
-        }
-        else{
-          [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
-        }
-      },
-      align(left)[#it.body]
-    )
+    let kind-length = 0pt
+    let kind-content = none
+
+    if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
+      counter(figure.where(kind: "sub-figure")).update(0)
+    }
+    // kind-contentの設定
+    if it.kind == table{
+      kind-content = [Table ] + context counter(figure.where(kind: table)).display() + [　]
+    }
+    else if it.kind == raw{
+      kind-content = [Code ] + context counter(figure.where(kind: raw)).display() + [　]
+    }
+    else if it.kind == "sub-figure"{
+      kind-content = it.supplement + context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0)) + [　]
+    }
+    else{
+      kind-content = [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
+    }
+
+    // kind-contentの長さを測定
+    kind-length = measure(box(kind-content)).width
+    let space-length = measure(sym.space.thin).width
+
+    // captionの出力
+    block[
+      #set par(hanging-indent: kind-length - space-length,)
+      #set align(left)
+
+      #box(kind-content)#sym.wj#it.body
+    ]
   }
   //表の設定
   let frame(stroke) = (x, y) => (

--- a/style/abst_master_style.typ
+++ b/style/abst_master_style.typ
@@ -63,30 +63,38 @@
     set par(leading: 4.5pt, justify: true)
     set text(size: 11.4pt)
     set align(top)
-    grid(
-      columns: 2,
-      {
-        if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
-          counter(figure.where(kind: "sub-figure")).update(0)
-        }
 
-        if it.kind == table{
-          [Table ] + context counter(figure.where(kind: table)).display() + [　]
-        }
-        else if it.kind == raw{
-          [Code ] + context counter(figure.where(kind: raw)).display() + [　]
-        }
-        else if it.kind == "sub-figure"{
-          it.supplement
-          context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0))
-          [　]
-        }
-        else{
-          [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
-        }
-      },
-      align(left)[#it.body]
-    )
+    let kind-length = 0pt
+    let kind-content = none
+
+    if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
+      counter(figure.where(kind: "sub-figure")).update(0)
+    }
+    // kind-contentの設定
+    if it.kind == table{
+      kind-content = [Table ] + context counter(figure.where(kind: table)).display() + [　]
+    }
+    else if it.kind == raw{
+      kind-content = [Code ] + context counter(figure.where(kind: raw)).display() + [　]
+    }
+    else if it.kind == "sub-figure"{
+      kind-content = it.supplement + context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0)) + [　]
+    }
+    else{
+      kind-content = [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
+    }
+
+    // kind-contentの長さを測定
+    kind-length = measure(box(kind-content)).width
+    let space-length = measure(sym.space.thin).width
+
+    // captionの出力
+    block[
+      #set par(hanging-indent: kind-length - space-length,)
+      #set align(left)
+
+      #box(kind-content)#sym.wj#it.body
+    ]
   }
   //表の設定
   let frame(stroke) = (x, y) => (

--- a/style/local_function.typ
+++ b/style/local_function.typ
@@ -44,9 +44,24 @@
       let heading-here = here-page in heading-page
 
       let fig-size = measure(figure(..arg)).height
-      let interval-size = 297mm - 63mm - fig-size - here().position().y
+      let interval-size = 297mm - 33mm - fig-size - here().position().y
 
-      text(font: "Adobe Blank")[#hide([A])]
+      let fig-bef = query(selector(figure).before(here())).map(it => {
+        if it.kind == image or it.kind == table{
+          (it.location().page(), measure(it).height)
+        }
+        else{
+          (0, 0pt)
+        }
+      })
+
+      for value in fig-bef{
+        if value.at(0) == here-page{
+          interval-size -= value.at(1)
+        }
+      }
+
+      place(hide[A])
 
       if heading-here {//章の先頭ページのとき
 
@@ -69,12 +84,14 @@
             ]
           }
           else{//図を下に配置できないとき，次ページの上に配置
-            pagebreak()
+            //pagebreak()
             [
+              #v(297mm - 63mm)
               #figure(
                 ..arg,
                 placement: top
               )#label
+              #v(-(297mm - 63mm))
             ]
           }
         }

--- a/style/thesis_style.typ
+++ b/style/thesis_style.typ
@@ -174,30 +174,38 @@
     set par(leading: 4.5pt, justify: true)
     set text(size: 11.4pt)
     set align(top)
-    grid(
-      columns: 2,
-      {
-        if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
-          counter(figure.where(kind: "sub-figure")).update(0)
-        }
 
-        if it.kind == table{
-          [Table ] + context counter(figure.where(kind: table)).display() + [　]
-        }
-        else if it.kind == raw{
-          [Code ] + context counter(figure.where(kind: raw)).display() + [　]
-        }
-        else if it.kind == "sub-figure"{
-          it.supplement
-          context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0))
-          [　]
-        }
-        else{
-          [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
-        }
-      },
-      align(left)[#it.body]
-    )
+    let kind-length = 0pt
+    let kind-content = none
+
+    if it.kind != "sub-figure"{// サブ図以外の場合，図番号を更新
+      counter(figure.where(kind: "sub-figure")).update(0)
+    }
+    // kind-contentの設定
+    if it.kind == table{
+      kind-content = [Table ] + context counter(figure.where(kind: table)).display() + [　]
+    }
+    else if it.kind == raw{
+      kind-content = [Code ] + context counter(figure.where(kind: raw)).display() + [　]
+    }
+    else if it.kind == "sub-figure"{
+      kind-content = it.supplement + context numbering("(a)", counter(figure.where(kind: "sub-figure")).get().at(0)) + [　]
+    }
+    else{
+      kind-content = [Fig. ] + context counter(figure.where(kind: image)).display() + [　]
+    }
+
+    // kind-contentの長さを測定
+    kind-length = measure(box(kind-content)).width
+    let space-length = measure(sym.space.thin).width
+
+    // captionの出力
+    block[
+      #set par(hanging-indent: kind-length - space-length,)
+      #set align(left)
+
+      #box(kind-content)#sym.wj#it.body
+    ]
   }
   set figure(numbering: num =>
     str(counter(heading).get().at(0)) + "." + str(num)


### PR DESCRIPTION
<!-- 不要な箇所は削除してもよい -->

## 変更の概要

- `fig`関数の自動配置で空白の段落を作成してしまうことがある問題を修正
- `fig`関数の自動配置が収束せず，レイアウトが崩れることがある問題を修正
- `bottom`に配置すべき項目が次ページの`top`に配置される可能性がある問題を修正
- 次ページの`top`に配置したとき，不適切な改ページを行う問題を修正
- `capiton`内に数式を入れると，図表番号とcaptionの位置がずれる問題を修正
